### PR TITLE
10 ミリ秒間隔 を 1 秒間隔のポーリングに変更して負荷を下げる

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -21,4 +21,4 @@ setInterval(() => {
   $.get('/server-status', {}, (data) => {
     loadavg.text(data.loadavg.toString());
   });
-}, 10);
+}, 1000);


### PR DESCRIPTION
gitignoreで操作するのでなく、git add app/entry.jsだけしてpushして無駄なものを省くことがやっとわかってきた。